### PR TITLE
Avoid pointy end on the events view hourly forecast

### DIFF
--- a/components/HourlyForecastItem.qml
+++ b/components/HourlyForecastItem.qml
@@ -19,8 +19,10 @@ Column {
         width: temperatureLabel.width
         height: temperatureGraph.height + temperatureLabel.height + padding
         anchors.horizontalCenter: parent.horizontalCenter
+
         Label {
             id: temperatureLabel
+
             text: TemperatureConverter.format(model.temperature)
             y: (1 - model.relativeTemperature) * temperatureGraph.height - parent.padding
         }

--- a/components/WeatherBanner.qml
+++ b/components/WeatherBanner.qml
@@ -270,12 +270,16 @@ ListItem {
                             active: weatherBanner.active && weatherBanner.hourly
                             weather: weatherBanner.weather
                             timestamp: weatherModel.timestamp
-                            onStatusChanged: if (status === Weather.Ready) temperatureGraph.update()
+                            onStatusChanged: {
+                                if (status === Weather.Ready)
+                                    temperatureGraph.update()
+                            }
                         }
 
                         delegate: Item {
                             width: hourlyForecastList.itemWidth
                             height: hourlyForecastList.height
+
                             HourlyForecastItem {
                                 hourMode: hourlyForecastList.hourMode
                                 highlighted: weatherBanner.highlighted

--- a/components/WeatherBanner.qml
+++ b/components/WeatherBanner.qml
@@ -249,7 +249,17 @@ ListItem {
                                     var array = []
                                     var model = hourlyForecastList.model
 
-                                    array[0] = 2 * model.get(0).relativeTemperature - model.get(1).relativeTemperature
+                                    // the first model temperature should be horizontally centered to the first
+                                    // HourlyForecastItem (could be better aligned here) which means that the
+                                    // first and last line graph values need some special interpolation or handling
+                                    // as they are before and after the forecast time values
+                                    // TODO: maybe just move the whole normalization here and
+                                    /// take into account the calculated values
+                                    array[0] = Math.min(1,
+                                                        Math.max(0,
+                                                                 2 * model.get(0).relativeTemperature
+                                                                 - model.get(1).relativeTemperature))
+
                                     for (var i = 0; i < model.visibleCount; i++) {
                                         array[i + 1] = model.get(i).relativeTemperature
                                     }


### PR DESCRIPTION
Got annoyed enough with the forecast line of rising temperatures. Just restricting to 0-1 on the interpolated value before the first known temperature seemed simple enough. Perhaps better would be moving the whole normalization here. It's now a bit silly being done separately on each backend.

Related: realized that the points don't exactly match now what's below in the timestamp cells or temperature number above the line. 