### PR TITLE
[weather] Drop badly shown weather provider from the cover. JB#64912

### DIFF
--- a/application/cover/CurrentWeatherCover.qml
+++ b/application/cover/CurrentWeatherCover.qml
@@ -8,8 +8,6 @@ import Sailfish.Silica 1.0
 import Sailfish.Weather 1.0
 
 Item {
-    readonly property string _providerImage: WeatherProvider.smallProviderImage()
-
     WeatherCoverItem {
         x: Theme.paddingLarge
         width: parent.width - 2*x
@@ -51,18 +49,5 @@ Item {
             centerIn: parent
             verticalCenterOffset: Theme.paddingSmall
         }
-    }
-    Image {
-        scale: 0.5
-        opacity: 0.5
-        anchors {
-            bottom: parent.bottom
-            // Keep clear of the bottom action icon without floating the provider badge too high.
-            bottomMargin: Math.round(Theme.itemSizeSmall / 2)
-            horizontalCenter: parent.horizontalCenter
-        }
-        source: _providerImage.length > 0
-                ? _providerImage + (highlighted ? Theme.highlightColor : Theme.primaryColor)
-                : ""
     }
 }


### PR DESCRIPTION
The code tried to avoid the bottom action but the implementation wasn't there. In addition at least in yr.no case the provider image has text which is very hard to read even with bigger cover sizes.

Think we could just drop this. The cover gets cleaner and don't think there should be any advertisement requirements going that far. Also it's not anyway shown in the multiple location mode of the cover.